### PR TITLE
Call NuGet.Using with correctly formatted left argument

### DIFF
--- a/APLSource/Cider/LoadNugetDependencies.aplf
+++ b/APLSource/Cider/LoadNugetDependencies.aplf
@@ -1,4 +1,4 @@
- list←x LoadNuGetDependencies(folder ns);p;verbose;batch;cfg;nuGetFolder;list;name;list2;targetNamespace;buff;dlls;assemblies;namespace;_dotnetReflection;exportedNamespaces;using_opts
+ list←x LoadNuGetDependencies(folder ns);p;verbose;batch;cfg;nuGetFolder;list;name;list2;targetNamespace;buff;dlls;assemblies;namespace;_dotnetReflection;exportedNamespaces
 ⍝ Load all dotnet namespace exported by NuGet dependencies from
 ⍝ folder into `ns` (namspace).
 ⍝ Returns a list with the names of all loaded NuGet packages.
@@ -24,8 +24,7 @@
          targetNamespace ns.⎕NS''
      :EndIf
      nuGetFolder←F.EnforceSlash nuGetFolder
-     using_opts←⎕JSON'{"includePrimary" : 0}'
-     ns._dotnet.⎕USING←using_opts NuGet.Using nuGetFolder
+     ns._dotnet.⎕USING←'(includePrimary : 0)'NuGet.Using nuGetFolder
      _dotnetReflection←⎕NS''
      _dotnetReflection.⎕USING←'System.Reflection,System.Runtime.dll'
      ⍝ Determine path to dlls of principal dependencies

--- a/APLSource/Cider/LoadNugetDependencies.aplf
+++ b/APLSource/Cider/LoadNugetDependencies.aplf
@@ -1,4 +1,4 @@
- list←x LoadNuGetDependencies(folder ns);p;verbose;batch;cfg;nuGetFolder;list;name;list2;targetNamespace;buff;dlls;assemblies;namespace;_dotnetReflection;exportedNamespaces
+ list←x LoadNuGetDependencies(folder ns);p;verbose;batch;cfg;nuGetFolder;list;name;list2;targetNamespace;buff;dlls;assemblies;namespace;_dotnetReflection;exportedNamespaces;using_opts
 ⍝ Load all dotnet namespace exported by NuGet dependencies from
 ⍝ folder into `ns` (namspace).
 ⍝ Returns a list with the names of all loaded NuGet packages.
@@ -24,7 +24,8 @@
          targetNamespace ns.⎕NS''
      :EndIf
      nuGetFolder←F.EnforceSlash nuGetFolder
-     ns._dotnet.⎕USING←'{includePrimary : 0}'NuGet.Using nuGetFolder
+     using_opts←⎕JSON'{"includePrimary" : 0}'
+     ns._dotnet.⎕USING←using_opts NuGet.Using nuGetFolder
      _dotnetReflection←⎕NS''
      _dotnetReflection.⎕USING←'System.Reflection,System.Runtime.dll'
      ⍝ Determine path to dlls of principal dependencies


### PR DESCRIPTION
Because of #62 the current call to `NuGet.Using` in `Cider.LoadNuGetDependencies` leads to a `DOMAIN ERROR`. The root cause for this problem is either in the NuGet API or even `⎕SE.Dyalog.Array.Deserialise`, but to alleviate this problem we can change the call to `NuGet.Using` to explicitly entering a namespace as left parameter.

Resolves #62