### PR TITLE
GitHub Actions for CI on Linux

### DIFF
--- a/.github/workflows/linuxCI.yml
+++ b/.github/workflows/linuxCI.yml
@@ -1,0 +1,55 @@
+name: Linux CI
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      -main
+
+jobs:
+  linux:
+    name: "CI - Linux - Dyalog APL ${{ matrix.dyalogVersion }} with .NET ${{ matrix.dotnetVersion }}"
+    runs-on: ubuntu-latest
+    timeout-minutes:
+      10
+    strategy:
+      matrix:
+        include:
+          - dyalogVersion: "19.0"
+            dotnetVersion: "8.x"
+      fail-fast: false
+    steps:
+      - name: Install Dyalog APL
+        run: |
+          DEBFILE=`curl -o - -s https://www.dyalog.com/uploads/php/download.dyalog.com/download.php?file=docker.metafile | awk -v v="${{ matrix.dyalogVersion }}" '$0~v && /deb/ {print $3}'`
+          curl -o /tmp/dyalog.deb ${DEBFILE}
+          sudo dpkg -i /tmp/dyalog.deb
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnetVersion }}
+      - name: Activate Tatin and Cider
+        run: LX="⎕SE.UCMD 'Tools.Activate all' ⋄ ⎕OFF" dyalog -b -s
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Tatin dependencies
+        run:  LX="⎕SE.UCMD 'Tatin.Version' ⋄ ⎕SE.Tatin.(CreateReInstallParms ReInstallDependencies './tatin-dependencies_dev') ⋄ ⎕OFF" dyalog -b -s 
+      - name: Run tests
+        run: |
+          runTest="⎕PW←500" 
+          runTest="${runTest} ⋄ ⎕SE.UCMD 'Cider.Version'"
+          runTest="${runTest} ⋄ ⎕SE.Cider.DEVELOPMENT←1"
+          runTest="${runTest} ⋄ opts←⎕NS '' ⋄ opts.(batch checkPackageVersions folder)←1 0 '.'"
+          runTest="${runTest} ⋄ ⎕SE.Cider.OpenProject opts"
+          runTest="${runTest} ⋄ #.Cider.TestCases.RunTestsForCI ⋄ ⎕OFF 1"
+          LX="${runTest}" dyalog -b -s
+      - name: Upload code coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: ./TestResults/CodeCoverage.html

--- a/.github/workflows/linuxCI.yml
+++ b/.github/workflows/linuxCI.yml
@@ -37,8 +37,6 @@ jobs:
         run: LX="⎕SE.UCMD 'Tools.Activate all' ⋄ ⎕OFF" dyalog -b -s
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Install Tatin dependencies
-        run:  LX="⎕SE.UCMD 'Tatin.Version' ⋄ ⎕SE.Tatin.(CreateReInstallParms ReInstallDependencies './tatin-dependencies_dev') ⋄ ⎕OFF" dyalog -b -s 
       - name: Run tests
         run: |
           runTest="⎕PW←500" 
@@ -49,6 +47,7 @@ jobs:
           runTest="${runTest} ⋄ #.Cider.TestCases.RunTestsForCI ⋄ ⎕OFF 1"
           LX="${runTest}" dyalog -b -s
       - name: Upload code coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report

--- a/APLSource/TestCases/Prepare.aplf
+++ b/APLSource/TestCases/Prepare.aplf
@@ -11,17 +11,17 @@
  flag←0
  :If ⎕NEXISTS testPath
      :If ⎕NEXISTS testFilename,'.profile'
-         ind←('Code Coverage' 0 1)CommTools.Select'Append' 'Replace' 'Neither'
+         ind←('CodeCoverageExists@Code Coverage' 0 1)CommTools.Select'Append' 'Replace' 'Neither'
          →(3=ind)/0
          flag←1
          :If 2=ind
              1 CodeCoverage.DeleteFiles testFilename
          :EndIf
      :Else
-         flag←0 CommTools.YesOrNo'Code coverage?'
+         flag←0 CommTools.YesOrNo'CodeCoverage@Code coverage?'
      :EndIf
  :Else
-     flag←0 CommTools.YesOrNo'Code coverage?'
+     flag←0 CommTools.YesOrNo'CodeCoverage@Code coverage?'
  :EndIf
  :If flag
      3 ⎕MKDIR testPath  ⍝

--- a/APLSource/TestCases/RunTestsForCI.aplf
+++ b/APLSource/TestCases/RunTestsForCI.aplf
@@ -1,0 +1,22 @@
+ RunTestsForCI;rc;log
+    ⍝ Runs all test with the batch flag on and the debug flag off,
+    ⍝ prints the messages from the test run
+    ⍝ and closes the APL session with return code 0 if the test run
+    ⍝ was successful and return code 1 if not.\\
+    ⍝ This test runner function is meant to be used for a CI
+    ⍝ pipeline.
+
+ ⍝ Always produce code coverage report
+ CommTools.YesOrNo_Answers←1 2⍴'CodeCoverage@' 'y'
+ ⍝ Always replace a code coverage report if it is already present
+ CommTools.Select_Choices←1 2⍴'CodeCoverageExists@' 2
+ Prepare
+ (rc log)←T.RunBatchTests 0
+ ⎕←↑log
+
+ :If 0<≢T.codeCoverage
+     {}CodeCoverage.ProcessData T.codeCoverage.filename
+     {}1 CodeCoverage.CreateReport T.codeCoverage.filename
+ :EndIf
+
+ ⎕OFF rc


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for CI on a Ubuntu VM. It installs Dyalog APL, .NET, Tatin and Cider (the latter two currently as supplied by Dyalog APL), runs all tests that can be run in batch mode, reports failures and finally publishes the code coverage report in html format as an artifact to GitHub.

The workflow is triggered by pushes to main and pull requests to main and can be triggered manually. It might be sensible to have it run in particular intervals to catch changes to Dyalog APL or .NET breaking Cider tests.

Resolves #66. 

This is probably not immediately useful since the test suite is currently failing because of #64 and #65.