### PR TITLE
Draft: GitHub Actions for CI on Windows

### DIFF
--- a/.github/workflows/windowsCI.yml
+++ b/.github/workflows/windowsCI.yml
@@ -1,0 +1,64 @@
+name: Windows CI
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      -main
+
+env:
+    DYALOG_NETCORE: 1 
+
+jobs:
+  linux:
+    name: "CI - Windows - Dyalog APL 19.0 with .NET 8.x"
+    runs-on: windows-latest
+    timeout-minutes:
+      10
+    steps:
+      - name: Install Dyalog APL
+        run: |
+            $downloadLinks = (Invoke-WebRequest https://www.dyalog.com/download-zone.htm?p=download).Links.href
+            $winDownloadLink = $downloadLinks | Where-Object { $_ -match "19\.0.*Windows" }
+            $winDownloadLink -match "download\.dyalog\.com.*" > $null
+            $winDownloadLink = $matches[0]
+            $client = New-Object System.Net.WebClient
+            $client.DownloadFile("https:\\$($winDownloadLink)", ".\windows_64_19.0.48959_unicode.zip")
+            Expand-Archive -Force .\windows_64_19.0.48959_unicode.zip .\windows_64_19.0.48959_unicode
+            cd .\windows_64_19.0.48959_unicode
+            $curPath = (Get-Location).ToString()
+            $msiPath = "$($curPath)\setup_64_unicode.msi"
+            $logFile = "$($curPath)\install_log.txt"
+            $MSIArguments = @("ALLUSERS=1", "/passive", "FROMGUI=1", "/i $($msiPath)", "/qn", "/norestart", "/L*v $($logFile)" )
+            Start-Process "msiexec.exe" -ArgumentList $MSIArguments -Wait -NoNewWindow
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.x"
+      - name: Activate Tatin and Cider
+        run: |
+            C:
+            cd "C:\\Program Files\\Dyalog\\Dyalog APL-64 19.0 Unicode" 
+            .\dyalog.exe -b -s LX="⎕SE.UCMD 'Tools.Activate all' ⋄ ⎕OFF"
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          runTest="⎕PW←500" 
+          runTest="${runTest} ⋄ ⎕SE.UCMD 'Cider.Version'"
+          runTest="${runTest} ⋄ ⎕SE.Cider.DEVELOPMENT←1"
+          runTest="${runTest} ⋄ opts←⎕NS '' ⋄ opts.(batch checkPackageVersions folder)←1 0 '.'"
+          runTest="${runTest} ⋄ ⎕SE.Cider.OpenProject opts"
+          runTest="${runTest} ⋄ #.Cider.TestCases.RunTestsForCI ⋄ ⎕OFF 1"
+          LX="${runTest}" "C:\\Program Files\\Dyalog\\Dyalog APL-64 19.0 Unicode\\dyalog.exe" -b -s
+        shell: bash
+      - name: Upload code coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: .\TestResults\CodeCoverage.html

--- a/.github/workflows/windowsCI.yml
+++ b/.github/workflows/windowsCI.yml
@@ -58,6 +58,7 @@ jobs:
           LX="${runTest}" "C:\\Program Files\\Dyalog\\Dyalog APL-64 19.0 Unicode\\dyalog.exe" -b -s
         shell: bash
       - name: Upload code coverage report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report

--- a/APLSource/TestCases/Prepare.aplf
+++ b/APLSource/TestCases/Prepare.aplf
@@ -11,17 +11,17 @@
  flag←0
  :If ⎕NEXISTS testPath
      :If ⎕NEXISTS testFilename,'.profile'
-         ind←('Code Coverage' 0 1)CommTools.Select'Append' 'Replace' 'Neither'
+         ind←('CodeCoverageExists@Code Coverage' 0 1)CommTools.Select'Append' 'Replace' 'Neither'
          →(3=ind)/0
          flag←1
          :If 2=ind
              1 CodeCoverage.DeleteFiles testFilename
          :EndIf
      :Else
-         flag←0 CommTools.YesOrNo'Code coverage?'
+         flag←0 CommTools.YesOrNo'CodeCoverage@Code coverage?'
      :EndIf
  :Else
-     flag←0 CommTools.YesOrNo'Code coverage?'
+     flag←0 CommTools.YesOrNo'CodeCoverage@Code coverage?'
  :EndIf
  :If flag
      3 ⎕MKDIR testPath  ⍝

--- a/APLSource/TestCases/RunTestsForCI.aplf
+++ b/APLSource/TestCases/RunTestsForCI.aplf
@@ -1,0 +1,22 @@
+ RunTestsForCI;rc;log
+    ⍝ Runs all test with the batch flag on and the debug flag off,
+    ⍝ prints the messages from the test run
+    ⍝ and closes the APL session with return code 0 if the test run
+    ⍝ was successful and return code 1 if not.\\
+    ⍝ This test runner function is meant to be used for a CI
+    ⍝ pipeline.
+
+ ⍝ Always produce code coverage report
+ CommTools.YesOrNo_Answers←1 2⍴'CodeCoverage@' 'y'
+ ⍝ Always replace a code coverage report if it is already present
+ CommTools.Select_Choices←1 2⍴'CodeCoverageExists@' 2
+ Prepare
+ (rc log)←T.RunBatchTests 0
+ ⎕←↑log
+
+ :If 0<≢T.codeCoverage
+     {}CodeCoverage.ProcessData T.codeCoverage.filename
+     {}1 CodeCoverage.CreateReport T.codeCoverage.filename
+ :EndIf
+
+ ⎕OFF rc


### PR DESCRIPTION
This PR adds a GitHub Actions workflow for CI on a Windows VM. It installs Dyalog APL, .NET, Tatin and Cider (the latter two currently as supplied by Dyalog APL), runs all tests that can be run in batch mode, reports failures and finally publishes the code coverage report in html format as an artifact to GitHub.

The workflow is triggered by pushes to main and pull requests to main and can be triggered manually. It might be sensible to have it run in particular intervals to catch changes to Dyalog APL or .NET breaking Cider tests.

This changes in this PR outside the workflow YAML file itself are identical to #69. 

Because of #64 it is expected that the test suite currently fails on windows. I mark this PR as a draft because I noted in a test run that not only (some of) the NuGet test are broken, but also the following unrelated tests that go through without problems on my local Windows machine:

Test_Misc_003
Test_Misc_015
Test_Open_001
Test_Open_008
Test_Open_050

I will try to find out why these errors occur before marking this PR as ready.