### PR TITLE
#122 Update URL for polyfill

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -49,7 +49,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
We should not be using files from polyfill.io, so use the copies from CloudFlare's copy of the repo instead.

See https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/